### PR TITLE
add serve command to build and test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,6 +15,7 @@ jobs:
           node-version: 21
       - run: npm ci
       - run: npm run build
+      - run: npm run start
       - run: npm run test
       - uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
adds "npm run start" to build and test workflow so that the action can run e2e tests